### PR TITLE
Add file configuration resource

### DIFF
--- a/vxsandbox/resources/config.py
+++ b/vxsandbox/resources/config.py
@@ -29,10 +29,13 @@ class FileConfigResource(SandboxResource):
         key = command.get('key')
         filename = self.config.get('keys').get(key)
         if filename is None:
-            return self.reply(command, success=False)
+            return self.reply_error(
+                command, reason='Configuration key %r not found' % (key,))
         try:
             with open(filename, 'r') as f:
                 value = f.read()
             return self.reply(command, value=value, success=True)
         except EnvironmentError:
-            return self.reply(command, success=False)
+            return self.reply_error(
+                command,
+                reason='Cannot read file %r' % (filename,))

--- a/vxsandbox/resources/config.py
+++ b/vxsandbox/resources/config.py
@@ -2,8 +2,6 @@
 
 """A file-based configuration resource for Vumi's application sandbox."""
 
-from twisted.internet.defer import inlineCallbacks
-
 from .utils import SandboxResource
 
 

--- a/vxsandbox/resources/config.py
+++ b/vxsandbox/resources/config.py
@@ -1,0 +1,40 @@
+# -*- test-case-name: vxsandbox.resources.tests.test_config -*-
+
+"""A file-based configuration resource for Vumi's application sandbox."""
+
+from twisted.internet.defer import inlineCallbacks
+
+from .utils import SandboxResource
+
+
+class FileConfigResource(SandboxResource):
+    """
+    Resource that provides access to a file-based configuration resource
+
+    Configuration options:
+
+    :param dict keys:
+        A mapping between configuration keys and filenames
+    """
+
+    def handle_get(self, api, command):
+        """
+        Retrieve the value of a configuration specified by a key.
+
+        Command fields:
+            - ``key``: The key whose configuration should be retrieved.
+
+        Reply:
+            - The contents of the file specified by the configuration mapping
+              for the given key.
+        """
+        key = command.get('key')
+        filename = self.config.get('keys').get(key)
+        if filename is None:
+            return self.reply(command, success=False)
+        try:
+            with open(filename, 'r') as f:
+                value = f.read()
+            return self.reply(command, value=value, success=True)
+        except EnvironmentError:
+            return self.reply(command, success=False)

--- a/vxsandbox/resources/tests/test_config.py
+++ b/vxsandbox/resources/tests/test_config.py
@@ -1,0 +1,41 @@
+from twisted.internet.defer import inlineCallbacks
+
+from vxsandbox.resources.config import FileConfigResource
+from vxsandbox.resources.tests.utils import ResourceTestCaseBase
+
+
+class TestFileConfigResource(ResourceTestCaseBase):
+
+    resource_cls = FileConfigResource
+
+    def create_config_file(self, content):
+        filename = self.mktemp()
+        with open(filename, 'w') as f:
+            f.write(content)
+        return filename
+
+    def create_resource(self, **file_mapping):
+        config = {
+            'keys': file_mapping
+        }
+        return super(TestFileConfigResource, self).create_resource(config)
+
+    @inlineCallbacks
+    def test_get_config(self):
+        test_content = 'Test content'
+        config_file = self.create_config_file(test_content)
+        self.create_resource(config=config_file)
+        reply = yield self.dispatch_command('get', key='config')
+        self.check_reply(reply, success=True, value=test_content)
+
+    @inlineCallbacks
+    def test_get_config_non_existing_file(self):
+        self.create_resource(config='foobar')
+        reply = yield self.dispatch_command('get', key='config')
+        self.check_reply(reply, success=False)
+
+    @inlineCallbacks
+    def test_get_config_non_existing_key(self):
+        self.create_resource()
+        reply = yield self.dispatch_command('get', key='bar')
+        self.check_reply(reply, success=False)

--- a/vxsandbox/resources/tests/test_config.py
+++ b/vxsandbox/resources/tests/test_config.py
@@ -33,9 +33,13 @@ class TestFileConfigResource(ResourceTestCaseBase):
         self.create_resource(config='foobar')
         reply = yield self.dispatch_command('get', key='config')
         self.check_reply(reply, success=False)
+        self.assertTrue('foobar' in reply['reason'])
+        self.assertTrue('Cannot read file' in reply['reason'])
 
     @inlineCallbacks
     def test_get_config_non_existing_key(self):
         self.create_resource()
         reply = yield self.dispatch_command('get', key='bar')
         self.check_reply(reply, success=False)
+        self.assertTrue('bar' in reply['reason'])
+        self.assertTrue('not found' in reply['reason'])


### PR DESCRIPTION
For the config of the configuration resource, have a mapping between keys and filenames. Resource looks up related filename according to key, and returns the contents of that file.