### PR TITLE
Copy over helper_metadata in outbound resource

### DIFF
--- a/vxsandbox/resources/outbound.py
+++ b/vxsandbox/resources/outbound.py
@@ -2,7 +2,18 @@
 
 """An outbound message sending for Vumi's application sandbox."""
 
+from twisted.internet.defer import succeed
+
+from vumi.errors import InvalidEndpoint
+
 from .utils import SandboxResource
+
+
+class InvalidOutboundCommand(Exception):
+    """
+    Internal exception raised when a sandboxed application sends
+    and invalid outbound command.
+    """
 
 
 class OutboundResource(SandboxResource):
@@ -14,6 +25,87 @@ class OutboundResource(SandboxResource):
     that aren't replies.
     """
 
+    def setup(self):
+        self._allowed_helper_metadata = set(
+            self.config.get('allowed_helper_metadata', []))
+
+    def _mkfail(self, command, reason):
+        return self.reply(command, success=False, reason=reason)
+
+    def _mkfaild(self, command, reason):
+        return succeed(self._mkfail(command, reason))
+
+    def _reply_callbacks(self, command):
+        callback = lambda r: self.reply(command, success=True)
+        errback = lambda f: self._mkfail(command, unicode(f.getErrorMessage()))
+        return (callback, errback)
+
+    def _get_cmd_params(self, api, command, params):
+        return [
+            getattr(self, '_param_%s' % name)(api, command) for name in params
+        ]
+
+    def _param_content(self, api, command):
+        if 'content' not in command:
+            raise InvalidOutboundCommand(u"'content' must be given.")
+        content = command['content']
+        if not isinstance(content, (unicode, type(None))):
+            raise InvalidOutboundCommand("'content' must be unicode or null.")
+        return content
+
+    def _param_continue_session(self, api, command):
+        continue_session = command.get('continue_session', True)
+        if continue_session not in (True, False):
+            raise InvalidOutboundCommand(
+                u"'continue_session' must be either true or false if given")
+        return continue_session
+
+    def _param_in_reply_to(self, api, command):
+        in_reply_to = command.get('in_reply_to')
+        if not isinstance(in_reply_to, unicode):
+            raise InvalidOutboundCommand(u"'in_reply_to' must be given.")
+        orig_msg = api.get_inbound_message(in_reply_to)
+        if orig_msg is None:
+            raise InvalidOutboundCommand(
+                u"Could not find original message with id: %r" % in_reply_to)
+        return orig_msg
+
+    def _param_helper_metadata(self, api, command):
+        helper_metadata = command.get('helper_metadata')
+        if helper_metadata in [None, {}]:
+            # No helper metadata, so return an empty dict.
+            return {}
+        if not self._allowed_helper_metadata:
+            raise InvalidOutboundCommand("'helper_metadata' is not allowed")
+        if not isinstance(helper_metadata, dict):
+            raise InvalidOutboundCommand(
+                "'helper_metadata' must be object or null.")
+        if any(key not in self._allowed_helper_metadata
+               for key in helper_metadata.iterkeys()):
+            raise InvalidOutboundCommand(
+                "'helper_metadata' may only contain the following keys: %s"
+                % ', '.join(sorted(self._allowed_helper_metadata)))
+        # Anything we have left is valid.
+        return helper_metadata
+
+    def _param_endpoint(self, api, command):
+        endpoint = command.get('endpoint')
+        if not isinstance(endpoint, unicode):
+            raise InvalidOutboundCommand(
+                u"'endpoint' must be given in sends.")
+        try:
+            self.app_worker.check_endpoint(endpoint)
+        except InvalidEndpoint:
+            raise InvalidOutboundCommand(
+                u"Endpoint %r not configured" % (endpoint,))
+        return endpoint
+
+    def _param_to_addr(self, api, command):
+        to_addr = command.get('to_addr')
+        if not isinstance(to_addr, unicode):
+            raise InvalidOutboundCommand(u"'to_addr' must be given in sends.")
+        return to_addr
+
     def handle_reply_to(self, api, command):
         """
         Sends a reply to the individual who sent a received message.
@@ -24,6 +116,8 @@ class OutboundResource(SandboxResource):
               to.
             - ``continue_session``: Whether to continue the session (if any).
               Defaults to ``true``.
+            - ``helper_metadata``: An object of additional helper metadata
+              fields to include in the reply.
 
         Reply fields:
             - ``success``: ``true`` if the operation was successful, otherwise
@@ -40,13 +134,18 @@ class OutboundResource(SandboxResource):
                 function(reply) { api.log_info('Reply sent: ' +
                                                reply.success); });
         """
-        content = command['content']
-        continue_session = command.get('continue_session', True)
-        orig_msg = api.get_inbound_message(command['in_reply_to'])
-        d = self.app_worker.reply_to(orig_msg, content,
-                                     continue_session=continue_session)
-        d.addCallback(lambda r: self.reply(command, success=True))
-        return d
+        try:
+            content, orig_msg, continue_session, helper_metadata = (
+                self._get_cmd_params(api, command, [
+                    'content', 'in_reply_to', 'continue_session',
+                    'helper_metadata']))
+        except InvalidOutboundCommand, err:
+            return self._mkfaild(command, reason=unicode(err))
+
+        d = self.app_worker.reply_to(
+            orig_msg, content, continue_session=continue_session,
+            helper_metadata=helper_metadata)
+        return d.addCallbacks(*self._reply_callbacks(command))
 
     def handle_reply_to_group(self, api, command):
         """
@@ -58,6 +157,8 @@ class OutboundResource(SandboxResource):
               to.
             - ``continue_session``: Whether to continue the session (if any).
               Defaults to ``true``.
+            - ``helper_metadata``: An object of additional helper metadata
+              fields to include in the reply.
 
         Reply fields:
             - ``success``: ``true`` if the operation was successful, otherwise
@@ -74,13 +175,18 @@ class OutboundResource(SandboxResource):
                 function(reply) { api.log_info('Reply to group sent: ' +
                                                reply.success); });
         """
-        content = command['content']
-        continue_session = command.get('continue_session', True)
-        orig_msg = api.get_inbound_message(command['in_reply_to'])
-        d = self.app_worker.reply_to_group(orig_msg, content,
-                                           continue_session=continue_session)
-        d.addCallback(lambda r: self.reply(command, success=True))
-        return d
+        try:
+            content, orig_msg, continue_session, helper_metadata = (
+                self._get_cmd_params(api, command, [
+                    'content', 'in_reply_to', 'continue_session',
+                    'helper_metadata']))
+        except InvalidOutboundCommand, err:
+            return self._mkfaild(command, reason=unicode(err))
+
+        d = self.app_worker.reply_to_group(
+            orig_msg, content, continue_session=continue_session,
+            helper_metadata=helper_metadata)
+        return d.addCallbacks(*self._reply_callbacks(command))
 
     def handle_send_to(self, api, command):
         """
@@ -91,6 +197,8 @@ class OutboundResource(SandboxResource):
             - ``to_addr``: The address of the recipient (e.g. an MSISDN).
             - ``endpoint``: The name of the endpoint to send the message via.
               Optional (default is ``"default"``).
+            - ``helper_metadata``: An object of additional helper metadata
+              fields to include in the message being sent.
 
         Reply fields:
             - ``success``: ``true`` if the operation was successful, otherwise
@@ -107,9 +215,49 @@ class OutboundResource(SandboxResource):
                 function(reply) { api.log_info('Message sent: ' +
                                                reply.success); });
         """
-        content = command['content']
-        to_addr = command['to_addr']
-        endpoint = command.get('endpoint', 'default')
-        d = self.app_worker.send_to(to_addr, content, endpoint=endpoint)
-        d.addCallback(lambda r: self.reply(command, success=True))
-        return d
+        if 'endpoint' not in command:
+            command['endpoint'] = u'default'
+        try:
+            content, to_addr, endpoint, helper_metadata = (
+                self._get_cmd_params(api, command, [
+                    'content', 'to_addr', 'endpoint', 'helper_metadata']))
+        except InvalidOutboundCommand, err:
+            return self._mkfaild(command, reason=unicode(err))
+
+        d = self.app_worker.send_to(
+            to_addr, content, endpoint=endpoint,
+            helper_metadata=helper_metadata)
+        return d.addCallbacks(*self._reply_callbacks(command))
+
+    def handle_send_to_endpoint(self, api, command):
+        """
+        Sends a message to a specified endpoint.
+        Command fields:
+            - ``content``: The body of the reply message.
+            - ``to_addr``: The address of the recipient (e.g. an MSISDN).
+            - ``endpoint``: The name of the endpoint to send the message via.
+            - ``helper_metadata``: An object of additional helper metadata
+              fields to include in the message being sent.
+        Reply fields:
+            - ``success``: ``true`` if the operation was successful, otherwise
+              ``false``.
+        Example:
+        .. code-block:: javascript
+            api.request(
+                'outbound.send_to_endpoint',
+                {content: 'Welcome!', to_addr: '+27831234567',
+                 endpoint: 'sms'},
+                function(reply) { api.log_info('Message sent: ' +
+                                               reply.success); });
+        """
+        try:
+            content, to_addr, endpoint, helper_metadata = (
+                self._get_cmd_params(api, command, [
+                    'content', 'to_addr', 'endpoint', 'helper_metadata']))
+        except InvalidOutboundCommand, err:
+            return self._mkfaild(command, reason=unicode(err))
+
+        d = self.app_worker.send_to(
+            to_addr, content, endpoint=endpoint,
+            helper_metadata=helper_metadata)
+        return d.addCallbacks(*self._reply_callbacks(command))

--- a/vxsandbox/resources/tests/test_outbound.py
+++ b/vxsandbox/resources/tests/test_outbound.py
@@ -2,16 +2,50 @@ from twisted.internet.defer import succeed, inlineCallbacks
 
 from vxsandbox.resources.outbound import OutboundResource
 from vxsandbox.resources.tests.utils import ResourceTestCaseBase
+from vxsandbox.tests.utils import DummyAppWorker
+
+
+class StubbedAppWorker(DummyAppWorker):
+
+    class DummyApi(DummyAppWorker.DummyApi):
+        def __init__(self, inbound_messages):
+            self._inbound_messages = inbound_messages
+
+        def get_inbound_message(self, msg_id):
+            return self._inbound_messages.get(msg_id)
+
+    sandbox_api_cls = DummyApi
+
+    def __init__(self):
+        super(StubbedAppWorker, self).__init__()
+        self._inbound_messages = {}
+
+    def create_sandbox_api(self):
+        return self.sandbox_api_cls(self._inbound_messages)
+
+    def add_inbound_message(self, msg):
+        self._inbound_messages[msg['message_id']] = msg
 
 
 class TestOutboundResource(ResourceTestCaseBase):
 
+    app_worker_cls = StubbedAppWorker
     resource_cls = OutboundResource
 
     @inlineCallbacks
     def setUp(self):
         super(TestOutboundResource, self).setUp()
         yield self.create_resource({})
+        self.app_worker.add_inbound_message({u'message_id': u'known-id'})
+
+    @inlineCallbacks
+    def assert_cmd_fails(self, reason, cmd, resource_config=None, **cmd_args):
+        yield self.create_resource(resource_config or {})
+        reply = yield self.dispatch_command(cmd, **cmd_args)
+        self.check_reply(reply, success=False, reason=reason)
+        self.assertFalse(self.app_worker.mock_calls['send_to'], [])
+        self.assertFalse(self.app_worker.mock_calls['reply_to'], [])
+        self.assertFalse(self.app_worker.mock_calls['reply_to_group'], [])
 
     @inlineCallbacks
     def test_handle_reply_to(self):
@@ -53,3 +87,76 @@ class TestOutboundResource(ResourceTestCaseBase):
                 'endpoint': 'default', 'helper_metadata': {},
             }),
         ])
+
+    def test_reply_to_fails_with_no_content(self):
+        return self.assert_cmd_fails(
+            "'content' must be given.",
+            'reply_to', in_reply_to=u'known-id')
+
+    def test_reply_to_fails_with_bad_content(self):
+        return self.assert_cmd_fails(
+            "'content' must be unicode or null.",
+            'reply_to', content=5, in_reply_to=u'known-id')
+
+    def test_reply_to_fails_with_no_in_reply_to(self):
+        return self.assert_cmd_fails(
+            "'in_reply_to' must be given.",
+            'reply_to', content=u'foo')
+
+    def test_reply_to_fails_with_bad_id(self):
+        return self.assert_cmd_fails(
+            "Could not find original message with id: u'unknown'",
+            'reply_to', content='Hello?', in_reply_to=u'unknown')
+
+    def test_reply_to_helper_metadata_not_allowed(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' is not allowed",
+            'reply_to',
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_helper_metadata_invalid(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            'reply_to',
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_helper_metadata_wrong_type(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' must be object or null.",
+            'reply_to',
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata="Not a dict.")
+
+    def test_reply_to_group_fails_with_no_content(self):
+        return self.assert_cmd_fails(
+            "'content' must be given.",
+            'reply_to_group', in_reply_to=u'known-id')
+
+    def test_reply_to_group_fails_with_no_in_reply_to(self):
+        return self.assert_cmd_fails(
+            "'in_reply_to' must be given.",
+            'reply_to_group', content=u'foo')
+
+    def test_reply_to_group_fails_with_bad_id(self):
+        return self.assert_cmd_fails(
+            "Could not find original message with id: u'unknown'",
+            'reply_to_group', content='Hello?', in_reply_to=u'unknown')
+
+    def test_reply_to_group_helper_metadata_not_allowed(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' is not allowed",
+            'reply_to_group',
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_group_helper_metadata_invalid(self):
+        return self.assert_cmd_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            'reply_to_group',
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})

--- a/vxsandbox/resources/tests/test_outbound.py
+++ b/vxsandbox/resources/tests/test_outbound.py
@@ -1,5 +1,7 @@
 from twisted.internet.defer import succeed, inlineCallbacks
 
+from vumi.errors import InvalidEndpoint
+
 from vxsandbox.resources.outbound import OutboundResource
 from vxsandbox.resources.tests.utils import ResourceTestCaseBase
 from vxsandbox.tests.utils import DummyAppWorker
@@ -19,12 +21,21 @@ class StubbedAppWorker(DummyAppWorker):
     def __init__(self):
         super(StubbedAppWorker, self).__init__()
         self._inbound_messages = {}
+        self._valid_endpoints = set(['default'])
+
+    def check_endpoint(self, endpoint):
+        if endpoint not in self._valid_endpoints:
+            raise InvalidEndpoint(
+                "Endpoint %r is not configured" % (endpoint,))
 
     def create_sandbox_api(self):
         return self.sandbox_api_cls(self._inbound_messages)
 
     def add_inbound_message(self, msg):
         self._inbound_messages[msg['message_id']] = msg
+
+    def add_endpoint(self, endpoint):
+        self._valid_endpoints.add(endpoint)
 
 
 class TestOutboundResource(ResourceTestCaseBase):
@@ -47,8 +58,13 @@ class TestOutboundResource(ResourceTestCaseBase):
         self.assertFalse(self.app_worker.mock_calls['reply_to'], [])
         self.assertFalse(self.app_worker.mock_calls['reply_to_group'], [])
 
+    def assert_sent(self, to_addr, content, msg_options):
+        self.assertEqual(self.app_worker.mock_calls['send_to'], [
+            ((to_addr, content), msg_options),
+        ])
+
     @inlineCallbacks
-    def test_handle_reply_to(self):
+    def test_reply_to(self):
         self.app_worker.mock_returns['reply_to'] = succeed(None)
         self.api.get_inbound_message = lambda msg_id: msg_id
         reply = yield self.dispatch_command('reply_to', content='hello',
@@ -61,8 +77,49 @@ class TestOutboundResource(ResourceTestCaseBase):
             }),
         ])
 
+    def assert_reply_to_fails(self, reason, **kw):
+        return self.assert_cmd_fails(reason, 'reply_to', **kw)
+
+    def test_reply_to_fails_with_no_content(self):
+        return self.assert_reply_to_fails(
+            "'content' must be given.", in_reply_to=u'known-id')
+
+    def test_reply_to_fails_with_bad_content(self):
+        return self.assert_reply_to_fails(
+            "'content' must be unicode or null.",
+            content=5, in_reply_to=u'known-id')
+
+    def test_reply_to_fails_with_no_in_reply_to(self):
+        return self.assert_reply_to_fails(
+            "'in_reply_to' must be given.", content=u'foo')
+
+    def test_reply_to_fails_with_bad_id(self):
+        return self.assert_reply_to_fails(
+            "Could not find original message with id: u'unknown'",
+            content='Hello?', in_reply_to=u'unknown')
+
+    def test_reply_to_helper_metadata_not_allowed(self):
+        return self.assert_reply_to_fails(
+            "'helper_metadata' is not allowed",
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_helper_metadata_invalid(self):
+        return self.assert_reply_to_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_helper_metadata_wrong_type(self):
+        return self.assert_reply_to_fails(
+            "'helper_metadata' must be object or null.",
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata="Not a dict.")
+
     @inlineCallbacks
-    def test_handle_reply_to_group(self):
+    def test_reply_to_group(self):
         self.app_worker.mock_returns['reply_to_group'] = succeed(None)
         self.api.get_inbound_message = lambda msg_id: msg_id
         reply = yield self.dispatch_command('reply_to_group', content='hello',
@@ -75,8 +132,37 @@ class TestOutboundResource(ResourceTestCaseBase):
             }),
         ])
 
+    def assert_reply_to_group_fails(self, reason, **kw):
+        return self.assert_cmd_fails(reason, 'reply_to_group', **kw)
+
+    def test_reply_to_group_fails_with_no_content(self):
+        return self.assert_reply_to_group_fails(
+            "'content' must be given.", in_reply_to=u'known-id')
+
+    def test_reply_to_group_fails_with_no_in_reply_to(self):
+        return self.assert_reply_to_group_fails(
+            "'in_reply_to' must be given.", content=u'foo')
+
+    def test_reply_to_group_fails_with_bad_id(self):
+        return self.assert_reply_to_group_fails(
+            "Could not find original message with id: u'unknown'",
+            content='Hello?', in_reply_to=u'unknown')
+
+    def test_reply_to_group_helper_metadata_not_allowed(self):
+        return self.assert_reply_to_group_fails(
+            "'helper_metadata' is not allowed",
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
+    def test_reply_to_group_helper_metadata_invalid(self):
+        return self.assert_reply_to_group_fails(
+            "'helper_metadata' may only contain the following keys: voice",
+            resource_config={'allowed_helper_metadata': ['voice']},
+            to_addr='6789', content='bar', in_reply_to=u'known-id',
+            helper_metadata={'go': {'conversation': 'someone-elses'}})
+
     @inlineCallbacks
-    def test_handle_send_to(self):
+    def test_send_to(self):
         self.app_worker.mock_returns['send_to'] = succeed(None)
         reply = yield self.dispatch_command('send_to', content='hello',
                                             to_addr='1234',
@@ -88,75 +174,108 @@ class TestOutboundResource(ResourceTestCaseBase):
             }),
         ])
 
-    def test_reply_to_fails_with_no_content(self):
-        return self.assert_cmd_fails(
-            "'content' must be given.",
-            'reply_to', in_reply_to=u'known-id')
+    @inlineCallbacks
+    def test_send_to_endpoint(self):
+        self.app_worker.add_endpoint('extra_endpoint')
+        self.app_worker.mock_returns['send_to'] = succeed(None)
+        yield self.create_resource({})
+        reply = yield self.dispatch_command(
+            'send_to_endpoint', endpoint='extra_endpoint', to_addr='6789',
+            content='bar')
+        self.check_reply(reply)
+        self.assert_sent('6789', 'bar', {
+            'endpoint': 'extra_endpoint',
+            'helper_metadata': {},
+        })
 
-    def test_reply_to_fails_with_bad_content(self):
-        return self.assert_cmd_fails(
+    @inlineCallbacks
+    def test_send_to_endpoint_null_content(self):
+        self.app_worker.add_endpoint('extra_endpoint')
+        self.app_worker.mock_returns['send_to'] = succeed(None)
+        yield self.create_resource({})
+        reply = yield self.dispatch_command(
+            'send_to_endpoint', endpoint='extra_endpoint', to_addr='6789',
+            content=None)
+        self.check_reply(reply)
+        self.assert_sent('6789', None, {
+            'endpoint': 'extra_endpoint',
+            'helper_metadata': {},
+        })
+
+    @inlineCallbacks
+    def test_send_to_endpoint_with_helper_metadata(self):
+        self.app_worker.add_endpoint('extra_endpoint')
+        self.app_worker.mock_returns['send_to'] = succeed(None)
+        yield self.create_resource({
+            'allowed_helper_metadata': ['voice'],
+        })
+
+        reply = yield self.dispatch_command(
+            'send_to_endpoint', endpoint='extra_endpoint', to_addr='6789',
+            content='bar',
+            helper_metadata={
+                'voice': {
+                    'speech_url': 'http://www.example.com/audio.wav',
+                },
+            })
+        self.check_reply(reply)
+        self.assert_sent('6789', 'bar', {
+            'endpoint': 'extra_endpoint',
+            'helper_metadata': {
+                'voice': {
+                    'speech_url': 'http://www.example.com/audio.wav',
+                },
+            },
+        })
+
+    def assert_send_to_endpoint_fails(self, reason, **kw):
+        return self.assert_cmd_fails(reason, 'send_to_endpoint', **kw)
+
+    def test_send_to_endpoint_not_configured(self):
+        return self.assert_send_to_endpoint_fails(
+            "Endpoint u'bad_endpoint' not configured",
+            endpoint='bad_endpoint', to_addr='6789',
+            content='bar')
+
+    def test_send_to_endpoint_missing_content(self):
+        return self.assert_send_to_endpoint_fails(
+            "'content' must be given.",
+            endpoint='extra_endpoint', to_addr='6789')
+
+    def test_send_to_endpoint_bad_content(self):
+        return self.assert_send_to_endpoint_fails(
             "'content' must be unicode or null.",
-            'reply_to', content=5, in_reply_to=u'known-id')
+            content=3, endpoint='extra_endpoint', to_addr='6789')
 
-    def test_reply_to_fails_with_no_in_reply_to(self):
-        return self.assert_cmd_fails(
-            "'in_reply_to' must be given.",
-            'reply_to', content=u'foo')
+    def test_send_to_endpoint_missing_endpoint(self):
+        return self.assert_send_to_endpoint_fails(
+            "'endpoint' must be given in sends.",
+            to_addr='6789', content='bar')
 
-    def test_reply_to_fails_with_bad_id(self):
-        return self.assert_cmd_fails(
-            "Could not find original message with id: u'unknown'",
-            'reply_to', content='Hello?', in_reply_to=u'unknown')
+    def test_send_to_endpoint_bad_endpoint(self):
+        return self.assert_send_to_endpoint_fails(
+            "'endpoint' must be given in sends.",
+            endpoint=None, to_addr='6789', content='bar')
 
-    def test_reply_to_helper_metadata_not_allowed(self):
-        return self.assert_cmd_fails(
+    def test_send_to_endpoint_missing_to_addr(self):
+        return self.assert_send_to_endpoint_fails(
+            "'to_addr' must be given in sends.",
+            endpoint='extra_endpoint', content='bar')
+
+    def test_send_to_endpoint_bad_to_addr(self):
+        return self.assert_send_to_endpoint_fails(
+            "'to_addr' must be given in sends.",
+            to_addr=None, endpoint='extra_endpoint', content='bar')
+
+    def test_send_to_endpoint_helper_metadata_not_allowed(self):
+        return self.assert_send_to_endpoint_fails(
             "'helper_metadata' is not allowed",
-            'reply_to',
-            to_addr='6789', content='bar', in_reply_to=u'known-id',
-            helper_metadata={'go': {'conversation': 'someone-elses'}})
+            to_addr='6789', endpoint='default', content='bar',
+            helper_metadata={'foo': 'not-allowed'})
 
-    def test_reply_to_helper_metadata_invalid(self):
-        return self.assert_cmd_fails(
+    def test_send_to_endpoint_helper_metadata_invalid(self):
+        return self.assert_send_to_endpoint_fails(
             "'helper_metadata' may only contain the following keys: voice",
-            'reply_to',
             resource_config={'allowed_helper_metadata': ['voice']},
-            to_addr='6789', content='bar', in_reply_to=u'known-id',
-            helper_metadata={'go': {'conversation': 'someone-elses'}})
-
-    def test_reply_to_helper_metadata_wrong_type(self):
-        return self.assert_cmd_fails(
-            "'helper_metadata' must be object or null.",
-            'reply_to',
-            resource_config={'allowed_helper_metadata': ['voice']},
-            to_addr='6789', content='bar', in_reply_to=u'known-id',
-            helper_metadata="Not a dict.")
-
-    def test_reply_to_group_fails_with_no_content(self):
-        return self.assert_cmd_fails(
-            "'content' must be given.",
-            'reply_to_group', in_reply_to=u'known-id')
-
-    def test_reply_to_group_fails_with_no_in_reply_to(self):
-        return self.assert_cmd_fails(
-            "'in_reply_to' must be given.",
-            'reply_to_group', content=u'foo')
-
-    def test_reply_to_group_fails_with_bad_id(self):
-        return self.assert_cmd_fails(
-            "Could not find original message with id: u'unknown'",
-            'reply_to_group', content='Hello?', in_reply_to=u'unknown')
-
-    def test_reply_to_group_helper_metadata_not_allowed(self):
-        return self.assert_cmd_fails(
-            "'helper_metadata' is not allowed",
-            'reply_to_group',
-            to_addr='6789', content='bar', in_reply_to=u'known-id',
-            helper_metadata={'go': {'conversation': 'someone-elses'}})
-
-    def test_reply_to_group_helper_metadata_invalid(self):
-        return self.assert_cmd_fails(
-            "'helper_metadata' may only contain the following keys: voice",
-            'reply_to_group',
-            resource_config={'allowed_helper_metadata': ['voice']},
-            to_addr='6789', content='bar', in_reply_to=u'known-id',
-            helper_metadata={'go': {'conversation': 'someone-elses'}})
+            to_addr='6789', endpoint='default', content='bar',
+            helper_metadata={'foo': 'not-allowed'})

--- a/vxsandbox/resources/tests/test_outbound.py
+++ b/vxsandbox/resources/tests/test_outbound.py
@@ -21,8 +21,11 @@ class TestOutboundResource(ResourceTestCaseBase):
                                             continue_session=True,
                                             in_reply_to='msg1')
         self.check_reply(reply, success=True)
-        self.assertEqual(self.app_worker.mock_calls['reply_to'],
-                         [(('msg1', 'hello'), {'continue_session': True})])
+        self.assertEqual(self.app_worker.mock_calls['reply_to'], [
+            (('msg1', 'hello'), {
+                'continue_session': True, 'helper_metadata': {}
+            }),
+        ])
 
     @inlineCallbacks
     def test_handle_reply_to_group(self):
@@ -32,8 +35,11 @@ class TestOutboundResource(ResourceTestCaseBase):
                                             continue_session=True,
                                             in_reply_to='msg1')
         self.check_reply(reply, success=True)
-        self.assertEqual(self.app_worker.mock_calls['reply_to_group'],
-                         [(('msg1', 'hello'), {'continue_session': True})])
+        self.assertEqual(self.app_worker.mock_calls['reply_to_group'], [
+            (('msg1', 'hello'), {
+                'continue_session': True, 'helper_metadata': {},
+            }),
+        ])
 
     @inlineCallbacks
     def test_handle_send_to(self):
@@ -42,5 +48,8 @@ class TestOutboundResource(ResourceTestCaseBase):
                                             to_addr='1234',
                                             tag='default')
         self.check_reply(reply, success=True)
-        self.assertEqual(self.app_worker.mock_calls['send_to'],
-                         [(('1234', 'hello'), {'endpoint': 'default'})])
+        self.assertEqual(self.app_worker.mock_calls['send_to'], [
+            (('1234', 'hello'), {
+                'endpoint': 'default', 'helper_metadata': {},
+            }),
+        ])

--- a/vxsandbox/resources/tests/test_outbound.py
+++ b/vxsandbox/resources/tests/test_outbound.py
@@ -54,9 +54,9 @@ class TestOutboundResource(ResourceTestCaseBase):
         yield self.create_resource(resource_config or {})
         reply = yield self.dispatch_command(cmd, **cmd_args)
         self.check_reply(reply, success=False, reason=reason)
-        self.assertFalse(self.app_worker.mock_calls['send_to'], [])
-        self.assertFalse(self.app_worker.mock_calls['reply_to'], [])
-        self.assertFalse(self.app_worker.mock_calls['reply_to_group'], [])
+        self.assertEqual(self.app_worker.mock_calls['send_to'], [])
+        self.assertEqual(self.app_worker.mock_calls['reply_to'], [])
+        self.assertEqual(self.app_worker.mock_calls['reply_to_group'], [])
 
     def assert_sent(self, to_addr, content, msg_options):
         self.assertEqual(self.app_worker.mock_calls['send_to'], [


### PR DESCRIPTION
In the outbound resource, helper_metadata is not copied over. You should be able to specify which helper_metadata fields to copy over in the application config, and only those fields should be copied over, similar to how it's done in https://github.com/praekelt/vumi-go/blob/develop/go/apps/jsbox/outbound.py#L83