### PR TITLE
HTTP Resource invalidates HEAD requests with no body but Content-Length set

### DIFF
--- a/vxsandbox/resources/http.py
+++ b/vxsandbox/resources/http.py
@@ -224,10 +224,10 @@ class HttpClientResource(SandboxResource):
         d = http_client.request(method, url, headers=headers, data=data,
                                 files=files, timeout=timeout)
 
-        d.addCallback(self._ensure_data_limit, data_limit)
+        d.addCallback(self._ensure_data_limit, method, data_limit)
         return d
 
-    def _ensure_data_limit(self, response, data_limit):
+    def _ensure_data_limit(self, response, method, data_limit):
         header = response.headers.getRawHeaders('Content-Length')
 
         def data_limit_check(response, length):
@@ -237,7 +237,7 @@ class HttpClientResource(SandboxResource):
                     % (length, data_limit,))
             return response
 
-        if header is None:
+        if header is None or method.upper() in ['DELETE', 'HEAD']:
             d = response.content()
             d.addCallback(lambda body: data_limit_check(response, len(body)))
             return d

--- a/vxsandbox/resources/http.py
+++ b/vxsandbox/resources/http.py
@@ -237,7 +237,7 @@ class HttpClientResource(SandboxResource):
                     % (length, data_limit,))
             return response
 
-        if header is None or method.upper() in ['DELETE', 'HEAD']:
+        if header is None or method.upper() == 'HEAD':
             d = response.content()
             d.addCallback(lambda body: data_limit_check(response, len(body)))
             return d

--- a/vxsandbox/resources/tests/test_http.py
+++ b/vxsandbox/resources/tests/test_http.py
@@ -374,17 +374,6 @@ class TestHttpClientResource(ResourceTestCaseBase):
         self.assert_http_request('https://www.example.com', method='HEAD')
 
     @inlineCallbacks
-    def test_data_limit_exceeded_using_delete_method(self):
-        self.http_request_succeed('', headers={
-            'Content-Length': self.resource.DEFAULT_DATA_LIMIT + 1,
-        })
-        reply = yield self.dispatch_command(
-            'delete', url='https://www.example.com',)
-        self.assertTrue(reply['success'])
-        self.assertEqual(reply['body'], "")
-        self.assert_http_request('https://www.example.com', method='DELETE')
-
-    @inlineCallbacks
     def test_data_limit_exceeded_using_header(self):
         self.http_request_succeed('', headers={
             'Content-Length': self.resource.DEFAULT_DATA_LIMIT + 1,

--- a/vxsandbox/resources/tests/test_http.py
+++ b/vxsandbox/resources/tests/test_http.py
@@ -363,6 +363,28 @@ class TestHttpClientResource(ResourceTestCaseBase):
             })
 
     @inlineCallbacks
+    def test_data_limit_exceeded_using_head_method(self):
+        self.http_request_succeed('', headers={
+            'Content-Length': self.resource.DEFAULT_DATA_LIMIT + 1,
+        })
+        reply = yield self.dispatch_command(
+            'head', url='https://www.example.com',)
+        self.assertTrue(reply['success'])
+        self.assertEqual(reply['body'], "")
+        self.assert_http_request('https://www.example.com', method='HEAD')
+
+    @inlineCallbacks
+    def test_data_limit_exceeded_using_delete_method(self):
+        self.http_request_succeed('', headers={
+            'Content-Length': self.resource.DEFAULT_DATA_LIMIT + 1,
+        })
+        reply = yield self.dispatch_command(
+            'delete', url='https://www.example.com',)
+        self.assertTrue(reply['success'])
+        self.assertEqual(reply['body'], "")
+        self.assert_http_request('https://www.example.com', method='DELETE')
+
+    @inlineCallbacks
     def test_data_limit_exceeded_using_header(self):
         self.http_request_succeed('', headers={
             'Content-Length': self.resource.DEFAULT_DATA_LIMIT + 1,


### PR DESCRIPTION
If the advertised `Content-Length` is bigger than the allowed `data_limit` the request is cancelled even if there is no response body. 