### PR TITLE
Add raven as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'Twisted>=13.1.0',
         'vumi>=0.5',
+        'raven==3.5.2',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/vxsandbox/resources/tests/test_http.py
+++ b/vxsandbox/resources/tests/test_http.py
@@ -160,15 +160,6 @@ class TestHttpClientResource(ResourceTestCaseBase):
         self.assertEqual(
             self.get_context(context_factory).get_verify_mode(), VERIFY_NONE)
 
-    def test_make_context_factory_sslv3_verify_none(self):
-        context_factory = make_context_factory(
-            verify_options=VERIFY_NONE, ssl_method=SSLv3_METHOD)
-        self.assertIsInstance(context_factory, HttpClientContextFactory)
-        self.assertEqual(context_factory.verify_options, VERIFY_NONE)
-        self.assertEqual(context_factory.ssl_method, SSLv3_METHOD)
-        self.assertEqual(
-            self.get_context(context_factory).get_verify_mode(), VERIFY_NONE)
-
     def test_make_context_factory_no_method_verify_peer(self):
         # This test's behaviour depends on the version of Twisted being used.
         context_factory = make_context_factory(verify_options=VERIFY_PEER)


### PR DESCRIPTION
Removed SSLv3 support, see: https://github.com/praekelt/vumi/pull/1074

